### PR TITLE
ARTHUR - Creation of Desnor Function and ajustments in Nor function, …

### DIFF
--- a/sources/Affine.cpp
+++ b/sources/Affine.cpp
@@ -1,15 +1,10 @@
 // Include libraries and functions
 #include "../includes/Eigen/Dense"
+#include "structs.h"
 #include "mmq.cpp"
 #include <iostream>
 
 // functions
-
-typedef struct AffineReturn
-{
-    Eigen::MatrixXd Xa;
-    Eigen::MatrixXd V;
-} AffineReturn;
 
 AffineReturn Affine(Eigen::MatrixXd Line, Eigen::MatrixXd Sample, Eigen::MatrixXd LineMeas, Eigen::MatrixXd SampleMeas)
 {

--- a/sources/Desnor.cpp
+++ b/sources/Desnor.cpp
@@ -1,6 +1,21 @@
 // Include libraries and functions
-
+#include "../includes/Eigen/Dense"
+#include <iostream>
+#include "Nor.cpp"
 // functions
-void Desnormalization() {
 
+long ElementDesnormalization(long normalaizedValue, long OffSetFactor, long ScaleFactor) {
+    return (normalaizedValue*ScaleFactor)+OffSetFactor;
 };
+
+Eigen::MatrixXd ImgDesnormalization(Eigen::MatrixXd img, CorrectionValues desnorCorrection[]){
+    int row = img.rows();
+    int col = img.cols();
+
+    for(int i = 0; i < row; i++){
+        for(int j = 0; j < col; j++){
+            img(i,j) = ElementDesnormalization(img(i,j),desnorCorrection[0].off,desnorCorrection[0].scale);
+        }
+    }
+    return img;
+}

--- a/sources/Desnor.cpp
+++ b/sources/Desnor.cpp
@@ -1,20 +1,24 @@
 // Include libraries and functions
 #include "../includes/Eigen/Dense"
 #include <iostream>
-#include "Nor.cpp"
+#include "structs.h"
 // functions
 
-long ElementDesnormalization(long normalaizedValue, long OffSetFactor, long ScaleFactor) {
-    return (normalaizedValue*ScaleFactor)+OffSetFactor;
+long ElementDesnormalization(long normalaizedValue, long OffSetFactor, long ScaleFactor)
+{
+    return (normalaizedValue * ScaleFactor) + OffSetFactor;
 };
 
-Eigen::MatrixXd ImgDesnormalization(Eigen::MatrixXd img, CorrectionValues desnorCorrection[]){
+Eigen::MatrixXd ImgDesnormalization(Eigen::MatrixXd img, CorrectionValues desnorCorrection[])
+{
     int row = img.rows();
     int col = img.cols();
 
-    for(int i = 0; i < row; i++){
-        for(int j = 0; j < col; j++){
-            img(i,j) = ElementDesnormalization(img(i,j),desnorCorrection[0].off,desnorCorrection[0].scale);
+    for (int i = 0; i < row; i++)
+    {
+        for (int j = 0; j < col; j++)
+        {
+            img(i, j) = ElementDesnormalization(img(i, j), desnorCorrection[0].off, desnorCorrection[0].scale);
         }
     }
     return img;

--- a/sources/Nor.cpp
+++ b/sources/Nor.cpp
@@ -2,41 +2,39 @@
 #include "../includes/Eigen/Dense"
 #include "mmq.cpp"
 #include <iostream>
+#include "structs.h"
 
 /*
-struct to acesses the offset and scale 
-values for a property to be normalized 
+struct to acesses the offset and scale
+values for a property to be normalized
 */
-
-typedef struct norm_values{
-    long scale;
-    long off;
-} CorrectionValues;
-
 
 // functions
 
 /*
-function to take the a general value related to each 
+function to take the a general value related to each
 point (lat, long, height, line, collumn, for example) and normalize them
 */
-long ElementNormalization(long value, long OffSetFactor, long ScaleFactor){
+long ElementNormalization(long value, long OffSetFactor, long ScaleFactor)
+{
     return ((value - OffSetFactor) / ScaleFactor);
 }
-
 
 /*
 Function to normalize each element of the matrix
 The function takes an array that holds the offset and scale correction values for each property
 like line, collumn, latitude, etc.
 */
-Eigen::MatrixXd ImgNormalization(Eigen::MatrixXd img, CorrectionValues correction[]){
+Eigen::MatrixXd ImgNormalization(Eigen::MatrixXd img, CorrectionValues correction[])
+{
     int row = img.rows();
     int col = img.cols();
 
-    for(int i = 0; i < row; i++){
-        for(int j = 0; j < col; j++){
-            img(i,j) = ElementNormalization(img(i,j),correction[0].off,correction[0].scale);
+    for (int i = 0; i < row; i++)
+    {
+        for (int j = 0; j < col; j++)
+        {
+            img(i, j) = ElementNormalization(img(i, j), correction[0].off, correction[0].scale);
         }
     }
     return img;

--- a/sources/Nor.cpp
+++ b/sources/Nor.cpp
@@ -14,19 +14,14 @@ typedef struct norm_values{
 } CorrectionValues;
 
 
-typedef struct imgpoints{
-    long x;
-    long y;
-} Ponto;
-
 // functions
 
 /*
 function to take the a general value related to each 
 point (lat, long, height, line, collumn, for example) and normalize them
 */
-long ElementNormalization(long value, long CorrectionFactor, long ScaleFactor){
-    return ((value - CorrectionFactor) / ScaleFactor);
+long ElementNormalization(long value, long OffSetFactor, long ScaleFactor){
+    return ((value - OffSetFactor) / ScaleFactor);
 }
 
 

--- a/sources/mmq.cpp
+++ b/sources/mmq.cpp
@@ -1,11 +1,6 @@
 #include "../includes/Eigen/Dense"
 #include <iostream>
-
-typedef struct mmqReturn
-{
-    Eigen::MatrixXd Xa;
-    Eigen::MatrixXd V;
-} mmqReturn;
+#include "structs.h"
 
 // what is this operation?
 mmqReturn mmq(Eigen::MatrixXd A, Eigen::MatrixXd L)

--- a/sources/structs.h
+++ b/sources/structs.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "../includes/Eigen/Dense"
+
+typedef struct CorrectionValues
+{
+    long scale;
+    long off;
+} CorrectionValues;
+
+typedef struct mmqReturn
+{
+    Eigen::MatrixXd Xa;
+    Eigen::MatrixXd V;
+} mmqReturn;
+
+typedef struct AffineReturn
+{
+    Eigen::MatrixXd Xa;
+    Eigen::MatrixXd V;
+} AffineReturn;

--- a/tests/Desnor_tests.cpp
+++ b/tests/Desnor_tests.cpp
@@ -1,25 +1,29 @@
 // Inlcude Nor
 #include <iostream>
 #include "../includes/Eigen/Dense"
+#include "../includes/Eigen/Geometry"
 #include "../sources/Desnor.cpp"
 #include "../sources/Nor.cpp"
+#include "../sources/structs.h"
 // use the function nor with Asserts librarie, if we change this project to CMAKE we will use, CTEST probably
 // but in the init use this way
 
 /*
 HOW TO COMPILE THIS PROGRAM
 COMAND
-g++ -g -Wall -I ..\includes\Eigen\Eigen ..\sources\*.cpp .\Nor_tests.cpp -o teste1
+g++ -g -Wall -I ..\includes\Eigen\Eigen  .\Desnor_tests.cpp -o teste1
 maybe this is temporary
 */
 
 int main()
 {
-    CorrectionValues line,collumn;
-    line.off = 1; line.scale = 2;
-    collumn.off = 3; collumn.scale = 1;
+    CorrectionValues line, collumn;
+    line.off = 1;
+    line.scale = 2;
+    collumn.off = 3;
+    collumn.scale = 1;
 
-    CorrectionValues correcao[] = {line,collumn}; 
+    CorrectionValues correcao[] = {line, collumn};
 
     ElementNormalization(100, 100, 100); // Nor.cpp function
 
@@ -29,13 +33,18 @@ int main()
     mat(0, 1) = -2;
     mat(1, 1) = -1;
 
-    std::cout <<"Matrix pre normalizacao:\n" << mat << "\n" << std::endl;
-    
+    std::cout << "Matrix pre normalizacao:\n"
+              << mat << "\n"
+              << std::endl;
 
-    std::cout <<"Matrix pos normalizacao:\n" <<  ImgNormalization(mat,correcao) << "\n" <<std::endl;
-    
-    Eigen::MatrixXd NormalizedMatrix = ImgNormalization(mat,correcao);
-    std::cout <<"Matrix pos normalizacao:\n" <<  ImgDesnormalization(NormalizedMatrix,correcao) << "\n" <<std::endl;
+    std::cout << "Matrix pos normalizacao:\n"
+              << ImgNormalization(mat, correcao) << "\n"
+              << std::endl;
+
+    Eigen::MatrixXd NormalizedMatrix = ImgNormalization(mat, correcao);
+    std::cout << "Matrix pos normalizacao:\n"
+              << ImgDesnormalization(NormalizedMatrix, correcao) << "\n"
+              << std::endl;
 
     return 0;
 }

--- a/tests/Desnor_tests.cpp
+++ b/tests/Desnor_tests.cpp
@@ -1,0 +1,41 @@
+// Inlcude Nor
+#include <iostream>
+#include "../includes/Eigen/Dense"
+#include "../sources/Desnor.cpp"
+#include "../sources/Nor.cpp"
+// use the function nor with Asserts librarie, if we change this project to CMAKE we will use, CTEST probably
+// but in the init use this way
+
+/*
+HOW TO COMPILE THIS PROGRAM
+COMAND
+g++ -g -Wall -I ..\includes\Eigen\Eigen ..\sources\*.cpp .\Nor_tests.cpp -o teste1
+maybe this is temporary
+*/
+
+int main()
+{
+    CorrectionValues line,collumn;
+    line.off = 1; line.scale = 2;
+    collumn.off = 3; collumn.scale = 1;
+
+    CorrectionValues correcao[] = {line,collumn}; 
+
+    ElementNormalization(100, 100, 100); // Nor.cpp function
+
+    Eigen::Matrix<double, 4, 4> mat;
+    mat(0, 0) = 4;
+    mat(1, 0) = 3;
+    mat(0, 1) = -2;
+    mat(1, 1) = -1;
+
+    std::cout <<"Matrix pre normalizacao:\n" << mat << "\n" << std::endl;
+    
+
+    std::cout <<"Matrix pos normalizacao:\n" <<  ImgNormalization(mat,correcao) << "\n" <<std::endl;
+    
+    Eigen::MatrixXd NormalizedMatrix = ImgNormalization(mat,correcao);
+    std::cout <<"Matrix pos normalizacao:\n" <<  ImgDesnormalization(NormalizedMatrix,correcao) << "\n" <<std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
@Petreon quando compilei, tive alguns erros, como:

```
In file included from ../sources/Nor.cpp:3,
                 from Desnor_tests.cpp:5:
../sources/mmq.cpp:4:16: error: redefinition of ‘struct mmqReturn’
    4 | typedef struct mmqReturn
      |                ^~~~~~~~~
In file included from ../sources/Nor.cpp:3,
                 from ../sources/Desnor.cpp:4,
                 from Desnor_tests.cpp:4:
../sources/mmq.cpp:4:16: note: previous definition of ‘struct mmqReturn’
    4 | typedef struct mmqReturn
      |                ^~~~~~~~~
In file included from ../sources/Nor.cpp:3,
                 from Desnor_tests.cpp:5:
../sources/mmq.cpp:8:3: error: conflicting declaration ‘typedef int mmqReturn’
    8 | } mmqReturn;
      |   ^~~~~~~~~
In file included from ../sources/Nor.cpp:3,
                 from ../sources/Desnor.cpp:4,
                 from Desnor_tests.cpp:4:
../sources/mmq.cpp:8:3: note: previous declaration as ‘typedef struct mmqReturn mmqReturn’
    8 | } mmqReturn;
      |   ^~~~~~~~~
In file included from ../sources/Nor.cpp:3,
                 from Desnor_tests.cpp:5:
../sources/mmq.cpp:11:11: error: redefinition of ‘mmqReturn mmq(Eigen::MatrixXd, Eigen::MatrixXd)’
   11 | mmqReturn mmq(Eigen::MatrixXd A, Eigen::MatrixXd L)
      |           ^~~
In file included from ../sources/Nor.cpp:3,
                 from ../sources/Desnor.cpp:4,
                 from Desnor_tests.cpp:4:
../sources/mmq.cpp:11:11: note: ‘mmqReturn mmq(Eigen::MatrixXd, Eigen::MatrixXd)’ previously defined here
   11 | mmqReturn mmq(Eigen::MatrixXd A, Eigen::MatrixXd L)
      |           ^~~
In file included from Desnor_tests.cpp:5:
../sources/Nor.cpp:11:16: error: redefinition of ‘struct norm_values’
   11 | typedef struct norm_values{
      |                ^~~~~~~~~~~
In file included from ../sources/Desnor.cpp:4,
                 from Desnor_tests.cpp:4:
../sources/Nor.cpp:11:16: note: previous definition of ‘struct norm_values’
   11 | typedef struct norm_values{
      |                ^~~~~~~~~~~
In file included from Desnor_tests.cpp:5:
../sources/Nor.cpp:14:3: error: conflicting declaration ‘typedef int CorrectionValues’
   14 | } CorrectionValues;
      |   ^~~~~~~~~~~~~~~~
In file included from ../sources/Desnor.cpp:4,
                 from Desnor_tests.cpp:4:
../sources/Nor.cpp:14:3: note: previous declaration as ‘typedef struct norm_values CorrectionValues’
   14 | } CorrectionValues;
      |   ^~~~~~~~~~~~~~~~
In file included from Desnor_tests.cpp:5:
../sources/Nor.cpp:23:6: error: redefinition of ‘long int ElementNormalization(long int, long int, long int)’
   23 | long ElementNormalization(long value, long OffSetFactor, long ScaleFactor){
      |      ^~~~~~~~~~~~~~~~~~~~
In file included from ../sources/Desnor.cpp:4,
                 from Desnor_tests.cpp:4:
../sources/Nor.cpp:23:6: note: ‘long int ElementNormalization(long int, long int, long int)’ previously defined here
   23 | long ElementNormalization(long value, long OffSetFactor, long ScaleFactor){
      |      ^~~~~~~~~~~~~~~~~~~~
In file included from Desnor_tests.cpp:5:
../sources/Nor.cpp:33:17: error: redefinition of ‘Eigen::MatrixXd ImgNormalization(Eigen::MatrixXd, CorrectionValues*)’
   33 | Eigen::MatrixXd ImgNormalization(Eigen::MatrixXd img, CorrectionValues correction[]){
      |                 ^~~~~~~~~~~~~~~~
In file included from ../sources/Desnor.cpp:4,
                 from Desnor_tests.cpp:4:
../sources/Nor.cpp:33:17: note: ‘Eigen::MatrixXd ImgNormalization(Eigen::MatrixXd, CorrectionValues*)’ previously defined here
   33 | Eigen::MatrixXd ImgNormalization(Eigen::MatrixXd img, CorrectionValues correction[]){
```